### PR TITLE
Section5 #8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+lib/index.rb


### PR DESCRIPTION
index.rbは手を動かすためのファイルなのでGitHubには上げる必要がない。
よって.gitignoreにindex.rbを追加。